### PR TITLE
fixcar: CarPlay/play-button fixes + metadata dedup suppression fix

### DIFF
--- a/components/screens/ListenScreen.tsx
+++ b/components/screens/ListenScreen.tsx
@@ -1,6 +1,6 @@
 // components/screens/ListenScreen.tsx
 import { useRouter } from 'expo-router'
-import React, { useCallback, useEffect, useState } from 'react'
+import React, { useCallback, useEffect, useRef, useState } from 'react'
 import {
   Alert,
   AppState,
@@ -60,6 +60,16 @@ export default function ListenScreen({ isActive }: { pageIndex: number; isActive
   // (shows disconnected while a cast is still active) while JS is suspended in
   // the background.
   const [castButtonNonce, setCastButtonNonce] = useState(0)
+
+  // Live mirrors for async fetch callbacks: they compare against what is
+  // currently on screen without needing the state values in their deps
+  // (which would churn their identities and re-trigger effects).
+  const broadcastStatusRef = useRef(broadcastStatus)
+  const remoteImageUrlRef = useRef(remoteImageUrl)
+  useEffect(() => {
+    broadcastStatusRef.current = broadcastStatus
+    remoteImageUrlRef.current = remoteImageUrl
+  })
 
 
   const parseDescription = (blocks: any[]): string =>
@@ -242,8 +252,13 @@ export default function ListenScreen({ isActive }: { pageIndex: number; isActive
               setImageFailed(false)
               await updateMetadata(newShowTitle || 'éist', name, image.uri, showTimeRange)
             } else {
-              setRemoteImageUrl(null)
-              setImageFailed(true)
+              // Preload failed. If this exact image is already displayed (it
+              // loaded fine earlier), keep it rather than flashing the
+              // placeholder until the next successful poll.
+              if (remoteImageUrlRef.current !== image.uri) {
+                setRemoteImageUrl(null)
+                setImageFailed(true)
+              }
               await updateMetadata(newShowTitle || 'éist', name, undefined, showTimeRange)
             }
           } else {
@@ -269,8 +284,14 @@ export default function ListenScreen({ isActive }: { pageIndex: number; isActive
         }
       }
     } catch {
-      setBroadcastStatus('error')
-      await clearNowPlayingState()
+      // A fetch error is a network blip, not an off-air signal (that arrives
+      // as a successful response with status !== 'schedule'). If a live show
+      // is on screen, hold it instead of flashing the offline background and
+      // swapping back on the next successful poll.
+      if (broadcastStatusRef.current !== 'schedule') {
+        setBroadcastStatus('error')
+        await clearNowPlayingState()
+      }
     }
   }, [artistId, artistCache, artistName, remoteImageUrl, getArtistDetails, updateMetadata, clearNowPlayingState, preloadImage, currentTimezone])
 
@@ -352,8 +373,12 @@ export default function ListenScreen({ isActive }: { pageIndex: number; isActive
           setImageFailed(false)
           await updateMetadata(newShowTitle || 'éist', name, image.uri, showTimeRange)
         } else {
-          setRemoteImageUrl(null)
-          setImageFailed(true)
+          // Same rule as fetchLiveScheduleOnly: don't drop an image that is
+          // already on screen just because a re-preload of it failed.
+          if (remoteImageUrlRef.current !== image.uri) {
+            setRemoteImageUrl(null)
+            setImageFailed(true)
+          }
           await updateMetadata(newShowTitle || 'éist', name, undefined, showTimeRange)
         }
       } else {
@@ -365,8 +390,13 @@ export default function ListenScreen({ isActive }: { pageIndex: number; isActive
       // Mark loading as finished
       setIsContentLoading(false)
     } catch {
-      setBroadcastStatus('error')
-      await clearNowPlayingState()
+      setIsContentLoading(false)
+      // Same hold-last-known-good rule as fetchLiveScheduleOnly: only a
+      // successful off-air response may replace a live show on screen.
+      if (broadcastStatusRef.current !== 'schedule') {
+        setBroadcastStatus('error')
+        await clearNowPlayingState()
+      }
     }
   }, [getArtistDetails, updateMetadata, clearNowPlayingState, preloadImage, currentTimezone])
 
@@ -401,16 +431,33 @@ export default function ListenScreen({ isActive }: { pageIndex: number; isActive
   // (CarPlay / Android Auto) is handled centrally in TrackPlayerContext, which
   // is always mounted. This screen no longer schedules its own car refresh.
 
+  // The fetch effects below must run on page activation / a timer ONLY — not
+  // whenever isPlaying flips or a fetch callback picks up a new identity
+  // (artistCache/artistName/remoteImageUrl churn on every fetch). Re-running
+  // the full fetch on those re-renders set isContentLoading(true) each time,
+  // which blanked and re-showed the background artwork. Latest callbacks are
+  // read through refs so the effects can depend on isActive alone.
+  const isPlayingLatest = useRef(isPlaying)
+  const fetchNowPlayingWithArtistRef = useRef(fetchNowPlayingWithArtist)
+  const fetchLiveScheduleOnlyRef = useRef(fetchLiveScheduleOnly)
+  const fetchNextShowRef = useRef(fetchNextShow)
+  useEffect(() => {
+    isPlayingLatest.current = isPlaying
+    fetchNowPlayingWithArtistRef.current = fetchNowPlayingWithArtist
+    fetchLiveScheduleOnlyRef.current = fetchLiveScheduleOnly
+    fetchNextShowRef.current = fetchNextShow
+  })
+
   useEffect(() => {
     if (!isActive) return;
-    fetchNowPlayingWithArtist();
-    fetchNextShow();
+    fetchNowPlayingWithArtistRef.current();
+    fetchNextShowRef.current();
     const interval = setInterval(() => {
-      if (isPlaying) fetchLiveScheduleOnly();
-      fetchNextShow();
+      if (isPlayingLatest.current) fetchLiveScheduleOnlyRef.current();
+      fetchNextShowRef.current();
     }, 60000);
     return () => clearInterval(interval);
-  }, [isActive, fetchNowPlayingWithArtist, fetchLiveScheduleOnly, fetchNextShow, isPlaying]);
+  }, [isActive]);
 
   // Refresh now playing info whenever the app returns to the foreground
   useEffect(() => {
@@ -420,8 +467,8 @@ export default function ListenScreen({ isActive }: { pageIndex: number; isActive
         // session state (which can go stale while backgrounded).
         setCastButtonNonce((n) => n + 1)
         // Only refresh if we're playing - use lightweight function
-        if (isPlaying) {
-          fetchLiveScheduleOnly()
+        if (isPlayingLatest.current) {
+          fetchLiveScheduleOnlyRef.current()
         }
       }
     })
@@ -429,7 +476,7 @@ export default function ListenScreen({ isActive }: { pageIndex: number; isActive
     return () => {
       subscription.remove()
     }
-  }, [fetchLiveScheduleOnly, isPlaying])
+  }, [])
 
   // The Pager keeps every page mounted, so swiping away from Listen leaves this
   // screen's native Cast button alive but offscreen — where GCKUICastButton can

--- a/components/ui/ShowArtworkBackground.tsx
+++ b/components/ui/ShowArtworkBackground.tsx
@@ -11,7 +11,7 @@ export function ShowArtworkBackground({ source, onError }: {
   return (
     <>
       {source ? (
-        <Image source={source} style={StyleSheet.absoluteFill} contentFit="cover" onError={onError} />
+        <Image source={source} style={StyleSheet.absoluteFill} contentFit="cover" transition={400} onError={onError} />
       ) : null}
       <LinearGradient colors={['rgba(71,51,255,0.46)', 'rgba(71,51,255,0.46)']} style={StyleSheet.absoluteFill} />
       <LinearGradient colors={['rgba(8,4,26,0.35)','rgba(8,4,26,0)','rgba(8,4,26,0)','rgba(8,4,26,0.82)']} locations={[0,0.38,0.52,1]} style={StyleSheet.absoluteFill} />

--- a/components/ui/SpinningLogo.tsx
+++ b/components/ui/SpinningLogo.tsx
@@ -4,19 +4,13 @@ import { WebView } from 'react-native-webview';
 import { eistLogoHtml } from '../../assets/eistLogoHtml';
 
 export function SpinningLogo({ size = 100 }: { size?: number }) {
-  if (Platform.OS === 'web') return null; // web build: omit (or use an <iframe> later)
-
-  // Transparent WKWebViews on iOS often load their content but never composite the
-  // first frame until a layout pass forces it — so the logo shows blank on the root
-  // pager until you navigate away and back (which re-lays-out the overlay). Keep it
-  // opacity:0 until the content has loaded, then flip to 1; that state-driven style
-  // change is itself the composite nudge, so the logo paints on first mount without
-  // a remount flash. A timeout backstops the rare case where onLoadEnd doesn't fire.
   const [painted, setPainted] = useState(false);
   useEffect(() => {
     const t = setTimeout(() => setPainted(true), 400);
     return () => clearTimeout(t);
   }, []);
+
+  if (Platform.OS === 'web') return null;
 
   // Interactive: touches reach the canvas so the logo can be grabbed, flung and
   // eased back to auto-spin — matching the reference spinning-eist-logo physics.

--- a/context/CastContext.tsx
+++ b/context/CastContext.tsx
@@ -59,7 +59,7 @@ export type CastContextType = {
     artist: string,
     artworkUrl?: string,
     showTime?: string
-  ) => Promise<void>
+  ) => Promise<boolean>
 }
 
 const CastContextValue = createContext<CastContextType | undefined>(undefined)
@@ -73,7 +73,7 @@ const disabledCastContext: CastContextType = {
   isCastPlaying: false,
   castPlay: async () => false,
   castStop: async () => {},
-  updateCastMetadata: async () => {},
+  updateCastMetadata: async () => false,
 }
 
 export const CastProvider = ({ children }: { children: ReactNode }) => {
@@ -308,13 +308,14 @@ export const CastProvider = ({ children }: { children: ReactNode }) => {
   const updateCastMetadataFn = useCallback(
     async (title: string, artist: string, artworkUrl?: string, showTime?: string) => {
       if (!isCastConnected || !isCastPlaying) {
-        // Just store metadata for when cast starts
+        // Just store metadata for when cast starts — nothing was actually sent,
+        // so report failure to the caller (don't let it record a success key).
         currentMetadata.current = { title, artist, artworkUrl, showTime }
-        return
+        return false
       }
 
       currentMetadata.current = { title, artist, artworkUrl, showTime }
-      await updateCastMediaMetadata(title, artist, artworkUrl, showTime)
+      return await updateCastMediaMetadata(title, artist, artworkUrl, showTime)
     },
     [isCastConnected, isCastPlaying]
   )

--- a/context/TrackPlayerContext.tsx
+++ b/context/TrackPlayerContext.tsx
@@ -91,6 +91,9 @@ export const TrackPlayerProvider = ({ children }: { children: ReactNode }) => {
   const hasInitialized = useRef(false)
   const audioRef = useRef<HTMLAudioElement | null>(null)
   const lastMetadataRef = useRef<string>('')
+  // Separate success key for the cast target so a failed/deferred local (RNTP)
+  // update never marks cast as done and vice versa. See updateMetadata.
+  const lastCastMetadataRef = useRef<string>('')
   const isPlayingRef = useRef(isPlaying)
   // Mirror of isPlayerReady so mount-registered listeners / stale closures
   // (attemptStreamRestart -> play -> setupPlayer) read the LIVE readiness
@@ -704,19 +707,27 @@ export const TrackPlayerProvider = ({ children }: { children: ReactNode }) => {
     const resolvedShowTime = showTime ?? showTimeRef.current
 
     const key = `${title}\0${artist}\0${artworkUrl ?? ''}\0${resolvedShowTime}`
-    if (key === lastMetadataRef.current) return
-    lastMetadataRef.current = key
 
-    // Also update cast metadata if casting
+    // Also update cast metadata if casting. Dedup on its own success key so it
+    // records only after a successful cast update, independent of the local one.
     if (isCastConnected || isCastPlaying) {
-      try {
-        await updateCastMetadata(title, artist, artworkUrl, resolvedShowTime)
-      } catch (err) {
-        console.error('Failed to update cast metadata:', err)
+      if (key !== lastCastMetadataRef.current) {
+        try {
+          await updateCastMetadata(title, artist, artworkUrl, resolvedShowTime)
+          lastCastMetadataRef.current = key
+        } catch (err) {
+          console.error('Failed to update cast metadata:', err)
+        }
       }
     }
 
-    if (!isPlayerReady || isWeb) return
+    // Read the live readiness ref, not the render-captured isPlayerReady state,
+    // so a cold-start seed doesn't see a stale `false`. The local dedup key is
+    // recorded only AFTER a successful updateMetadataForTrack (below) — recording
+    // it here would let any early return (not ready, empty queue, out-of-bounds)
+    // or throw permanently suppress every later attempt for this show.
+    if (!isPlayerReadyRef.current || isWeb) return
+    if (key === lastMetadataRef.current) return
 
     try {
       const queue = await TrackPlayer.getQueue()
@@ -758,6 +769,7 @@ export const TrackPlayerProvider = ({ children }: { children: ReactNode }) => {
         _metadata_refresh: Date.now(),
       }
       await TrackPlayer.updateMetadataForTrack(trackIndex, metadata)
+      lastMetadataRef.current = key
     } catch (err) {
       console.error('Metadata update failed:', err)
     }

--- a/context/TrackPlayerContext.tsx
+++ b/context/TrackPlayerContext.tsx
@@ -16,7 +16,6 @@ import { getLockScreenImage, invalidateLockScreenImage, preloadLockScreenImage }
 import { setupTrackPlayer } from '../utils/trackPlayerSetup';
 import { getLiveShowInfo } from '../utils/liveShowInfo';
 import { resolveIsPlaying } from '../utils/playbackUiState';
-
 // Only import TrackPlayer on mobile platforms
 let TrackPlayer: any, Event: any, State: any;
 if (Platform.OS !== 'web') {
@@ -91,6 +90,7 @@ export const TrackPlayerProvider = ({ children }: { children: ReactNode }) => {
 
   const hasInitialized = useRef(false)
   const audioRef = useRef<HTMLAudioElement | null>(null)
+  const lastMetadataRef = useRef<string>('')
   const isPlayingRef = useRef(isPlaying)
   // Mirror of isPlayerReady so mount-registered listeners / stale closures
   // (attemptStreamRestart -> play -> setupPlayer) read the LIVE readiness
@@ -101,6 +101,9 @@ export const TrackPlayerProvider = ({ children }: { children: ReactNode }) => {
 
   // Separate user intent tracking from actual playback state
   const userPlay = useRef(false)
+
+  // Stable ref for play() so the CarPlay bridge listener never re-subscribes
+  const playRef = useRef<(options?: { castOnly?: boolean }) => Promise<void>>(async () => {})
 
   // Unified recovery state - keeps trying as long as user hasn't stopped
   const isRecovering = useRef(false);
@@ -314,12 +317,11 @@ export const TrackPlayerProvider = ({ children }: { children: ReactNode }) => {
   // Unified restart mechanism that uses user intent instead of current playing state
   const attemptStreamRestart = async (reason: string = 'unknown') => {
     if (isRecovering.current) return
-    
+
     // Use userPlay instead of isPlayingRef.current
     if (!userPlay.current) {
       return
     }
-
     isRecovering.current = true
 
     // Clear any existing retry timeout
@@ -581,22 +583,24 @@ export const TrackPlayerProvider = ({ children }: { children: ReactNode }) => {
         }
       }
 
-      // Fetch fresh metadata FIRST and pass directly to cleanResetPlayer
-      // (React setState is async so state won't be updated yet)
-      const metadata = await fetchAndUpdateShowMetadata()
+      // Start audio immediately with existing metadata so CarPlay's Now
+      // Playing controls go live without waiting for a network fetch.
+      // Metadata is refreshed after playback starts.
+      await cleanResetPlayer()
 
-      // Now perform clean reset with fresh metadata passed directly
-      await cleanResetPlayer(metadata || undefined)
-
-      // Start playback with muted volume to allow buffering without glitch
       await TrackPlayer.setVolume(0)
       await TrackPlayer.play()
       setIsPlaying(true)
       await storeLastPlayedState(true)
-      
+
+      // Now fetch fresh metadata and update (non-blocking for playback)
+      fetchAndUpdateShowMetadata().catch((err) =>
+        console.warn('Post-play metadata fetch failed:', err)
+      )
+
       // Wait 2 seconds for proper buffering to avoid startup glitch
       await new Promise(resolve => setTimeout(resolve, 2000))
-      
+
       // Gradually restore volume to avoid jarring audio start
       await TrackPlayer.setVolume(1)
 
@@ -616,6 +620,8 @@ export const TrackPlayerProvider = ({ children }: { children: ReactNode }) => {
       await attemptStreamRestart('play-error')
     }
   }, [isPlayerReady, isWeb, setupPlayer, attemptStreamRestart, cleanResetPlayer, fetchAndUpdateShowMetadata, isCastConnected, castPlay, showTitle, showArtist, showArtworkUrl])
+
+  useEffect(() => { playRef.current = play }, [play])
 
   const stop = useCallback(async () => {
     // Clear user intent when manually stopping
@@ -693,6 +699,10 @@ export const TrackPlayerProvider = ({ children }: { children: ReactNode }) => {
       showTimeRef.current = showTime
     }
     const resolvedShowTime = showTime ?? showTimeRef.current
+
+    const key = `${title}\0${artist}\0${artworkUrl ?? ''}\0${resolvedShowTime}`
+    if (key === lastMetadataRef.current) return
+    lastMetadataRef.current = key
 
     // Also update cast metadata if casting
     if (isCastConnected || isCastPlaying) {
@@ -794,14 +804,11 @@ export const TrackPlayerProvider = ({ children }: { children: ReactNode }) => {
 
     const emitter = new NativeEventEmitter(bridge)
     const sub = emitter.addListener('EistCarPlayPlay', () => {
-      // Fired on every CarPlay scene activation, not just once per connection.
-      // If the stream is already playing (user glanced at Maps and came back),
-      // restarting it would glitch the audio — only start when not playing.
       if (isPlayingRef.current) return
-      play().catch((error) => console.error('CarPlay play request failed:', error))
+      playRef.current().catch((error: unknown) => console.error('CarPlay play request failed:', error))
     })
     return () => sub.remove()
-  }, [isWeb, play])
+  }, [isWeb])
 
   useEffect(() => {
     setupPlayer()

--- a/context/TrackPlayerContext.tsx
+++ b/context/TrackPlayerContext.tsx
@@ -330,8 +330,11 @@ export const TrackPlayerProvider = ({ children }: { children: ReactNode }) => {
       retryTimeout.current = null
     }
 
-    // Don't change userPlay here - just update UI state
-    setIsPlaying(false)
+    // Deliberately do NOT setIsPlaying(false) here: this path only runs while
+    // userPlay is true, and the button must reflect the listening session, not
+    // recovery churn. Flipping it here made the button glitch Stop → Listen →
+    // Stop on every network change / rebuffer / retry. A genuine failure keeps
+    // retrying until the user presses Stop, which clears userPlay and the state.
 
     if (isWeb) {
       try {

--- a/context/TrackPlayerContext.tsx
+++ b/context/TrackPlayerContext.tsx
@@ -713,8 +713,14 @@ export const TrackPlayerProvider = ({ children }: { children: ReactNode }) => {
     if (isCastConnected || isCastPlaying) {
       if (key !== lastCastMetadataRef.current) {
         try {
-          await updateCastMetadata(title, artist, artworkUrl, resolvedShowTime)
-          lastCastMetadataRef.current = key
+          // Record the cast success key ONLY if the update actually went
+          // through. updateCastMediaMetadata swallows failures and returns
+          // false; recording on a mere promise-resolve would let one transient
+          // failure permanently suppress every retry for this show.
+          const castOk = await updateCastMetadata(title, artist, artworkUrl, resolvedShowTime)
+          if (castOk) {
+            lastCastMetadataRef.current = key
+          }
         } catch (err) {
           console.error('Failed to update cast metadata:', err)
         }
@@ -727,7 +733,18 @@ export const TrackPlayerProvider = ({ children }: { children: ReactNode }) => {
     // it here would let any early return (not ready, empty queue, out-of-bounds)
     // or throw permanently suppress every later attempt for this show.
     if (!isPlayerReadyRef.current || isWeb) return
-    if (key === lastMetadataRef.current) return
+
+    // Resolve the artwork the lock screen will actually use, then dedup on THAT.
+    // Android's two-pass flow calls updateMetadata twice with the same artworkUrl
+    // (once before preload -> fallback logo, once after -> real image); keying on
+    // the input URL alone would suppress the second pass and leave Android Auto /
+    // lock screen stuck on the fallback logo. Keying on the resolved value lets
+    // the fallback->real transition through while still deduping true repeats.
+    const isDeadAir = title.trim().length === 0
+    let artworkToUse = artworkUrl || require('../assets/images/eist-logo.png')
+    artworkToUse = getLockScreenImage(artworkToUse)
+    const localKey = `${title}\0${artist}\0${String(artworkToUse)}\0${resolvedShowTime}`
+    if (localKey === lastMetadataRef.current) return
 
     try {
       const queue = await TrackPlayer.getQueue()
@@ -745,14 +762,6 @@ export const TrackPlayerProvider = ({ children }: { children: ReactNode }) => {
         return
       }
 
-      const isDeadAir = title.trim().length === 0
-
-      // Use appropriate artwork for Android lock screen and Android Auto compatibility
-      let artworkToUse = artworkUrl || require('../assets/images/eist-logo.png')
-
-      // Use the lock screen image utility for proper Android handling
-      artworkToUse = getLockScreenImage(artworkToUse)
-
       const metadata = {
         title,
         artist: isDeadAir ? '' : (artist || ''),
@@ -769,7 +778,7 @@ export const TrackPlayerProvider = ({ children }: { children: ReactNode }) => {
         _metadata_refresh: Date.now(),
       }
       await TrackPlayer.updateMetadataForTrack(trackIndex, metadata)
-      lastMetadataRef.current = key
+      lastMetadataRef.current = localKey
     } catch (err) {
       console.error('Metadata update failed:', err)
     }

--- a/plugins/withCarPlay.js
+++ b/plugins/withCarPlay.js
@@ -12,89 +12,45 @@ const path = require('path');
 /**
  * Expo config plugin: minimal Apple CarPlay support for an audio app.
  *
- * NOT loaded by default. It is only added to the plugin list when
- * `EXPO_ENABLE_CARPLAY=true` (see app.config.ts), because the
- * `com.apple.developer.carplay-audio` entitlement it adds must first be:
- *   1. requested from / approved by Apple for the App ID, and
- *   2. present in the EAS signing (provisioning) profile.
+ * NOT loaded by default. Only added when EXPO_ENABLE_CARPLAY=true (see
+ * app.config.ts), since the `com.apple.developer.carplay-audio` entitlement
+ * must be approved by Apple and present in the EAS provisioning profile.
  *
- * ── Why this touches the app window (read before editing) ──────────────────
- * CarPlay is a second UIScene living alongside the phone UI, so enabling it
- * forces the whole app onto the iOS *scene* lifecycle (UIScene, iOS 13+). Once
- * `UIApplicationSupportsMultipleScenes` is true, UIKit stops using the
- * AppDelegate's hand-made `self.window`; every window must belong to a
- * UIWindowScene. The previous version of this plugin declared ONLY the CarPlay
- * scene and left the AppDelegate creating its own window — which orphaned the
- * phone window and produced a BLACK SCREEN that never launched on device.
+ * What this does: shows a single "éist" item in CarPlay; tapping it pushes
+ * the system Now Playing screen (CPNowPlayingTemplate). That screen's
+ * play/pause button drives MPRemoteCommandCenter directly, which
+ * react-native-track-player already handles — so no JS bridge is needed.
  *
- * The correct setup (per Apple + react-native-carplay) is a full scene
- * conversion of the phone UI:
- *   - Info.plist declares BOTH scene roles: a phone `UIWindowSceneSessionRole-
- *     Application` (PhoneSceneDelegate) and the CarPlay
- *     `CPTemplateApplicationSceneSessionRoleApplication` (CarPlaySceneDelegate).
- *   - AppDelegate builds the React Native root view but no longer creates a
- *     UIWindow (the scene owns it) — see withCarPlayAppDelegate.
- *   - PhoneSceneDelegate creates the phone UIWindow from its UIWindowScene and
- *     hosts the shared RN root view.
- *   - CarPlaySceneDelegate roots CarPlay on a one-item CPListTemplate ("éist
- *     radio") and pushes the system Now Playing template when it's tapped. Apple
- *     forbids CPNowPlayingTemplate as a root template, so it must be pushed.
+ * Why the phone scene delegate exists: enabling CarPlay makes the app a
+ * multi-scene (UIScene) app, and once that's on, UIKit stops using the
+ * AppDelegate's hand-made `self.window` — every window must come from a
+ * UIWindowScene. So the phone UI needs its own scene delegate too, or you
+ * get an orphaned window / black screen on launch. This is required
+ * plumbing, not something we can simplify away.
  *
- * The Now Playing screen (éist logo artwork + play/stop) is driven entirely by
- * the MPNowPlayingInfoCenter / MPRemoteCommandCenter data that
- * react-native-track-player already sets, so there is no second audio engine
- * and no JS bridge on the CarPlay side.
- *
- * NOTE: `ios/` is gitignored / prebuild-generated, so all of this lives in the
- * plugin — editing ios/ by hand would be wiped on the next prebuild/EAS build.
+ * `ios/` is gitignored / prebuild-generated, so all of this lives in the
+ * plugin — hand-editing ios/ would be wiped on the next prebuild/EAS build.
  */
 
 const CARPLAY_AUDIO_ENTITLEMENT = 'com.apple.developer.carplay-audio';
 
 const CARPLAY_SCENE_DELEGATE_SWIFT = `import CarPlay
-import MediaPlayer
 
-// ── Why the root is a CPListTemplate, not CPNowPlayingTemplate ──────────────
-// Apple does NOT allow CPNowPlayingTemplate as an audio app's ROOT template. Per
-// the CarPlay docs/forums it may only be *pushed* on top of a browsable root
-// (list/tab/grid), or is auto-pushed by the system once playback starts. The
-// previous version set CPNowPlayingTemplate.shared as the root, which is why the
-// car screen "didn't work well": metadata painted (it mirrors MPNowPlayingInfo-
-// Center, shared with the lock screen) but the template sat in an unsupported
-// position with flaky controls and no browse UI.
-//
-// So we root on a single-item CPListTemplate (mirroring the one "éist radio" item
-// Android Auto exposes) and *push* the shared Now Playing template when the item
-// is tapped. Artwork + play/stop still come entirely from the MPNowPlayingInfo-
-// Center / MPRemoteCommandCenter data react-native-track-player already sets, so
-// there's still no second audio engine and no JS bridge on the CarPlay side.
+// Apple does not allow CPNowPlayingTemplate as an audio app's ROOT template —
+// it can only be pushed on top of a browsable root. So we root on a single
+// "éist" list item and push Now Playing when it's tapped. Now Playing mirrors
+// MPNowPlayingInfoCenter (already set by react-native-track-player) and its
+// controls call straight into MPRemoteCommandCenter, so no JS bridge needed.
 @objc(CarPlaySceneDelegate)
 class CarPlaySceneDelegate: UIResponder, CPTemplateApplicationSceneDelegate {
   var interfaceController: CPInterfaceController?
-  // Cold-start ordering: sceneDidBecomeActive can fire before setRootTemplate's
-  // completion runs, and pushing Now Playing without a root in place fails. So
-  // activation only auto-plays once the root is set, and an early activation is
-  // parked in pendingAutoPlay for the completion handler to flush.
-  private var rootTemplateSet = false
-  private var pendingAutoPlay = false
 
   func templateApplicationScene(
     _ templateApplicationScene: CPTemplateApplicationScene,
     didConnect interfaceController: CPInterfaceController
   ) {
     self.interfaceController = interfaceController
-    // Apple forbids CPNowPlayingTemplate as a ROOT template, so we root on a
-    // one-item list — but the user never has to see or tap it: every scene
-    // activation (see sceneDidBecomeActive) starts playback and pushes Now
-    // Playing, so opening éist in the car lands straight on the transport screen.
-    interfaceController.setRootTemplate(makeRootTemplate(), animated: false) { [weak self] _, _ in
-      guard let self = self else { return }
-      self.rootTemplateSet = true
-      if self.pendingAutoPlay {
-        self.pendingAutoPlay = false
-        self.startPlaybackAndShowNowPlaying(animated: false)
-      }
-    }
+    interfaceController.setRootTemplate(makeRootTemplate(), animated: false, completion: nil)
   }
 
   func templateApplicationScene(
@@ -102,69 +58,22 @@ class CarPlaySceneDelegate: UIResponder, CPTemplateApplicationSceneDelegate {
     didDisconnectInterfaceController interfaceController: CPInterfaceController
   ) {
     self.interfaceController = nil
-    rootTemplateSet = false
-    pendingAutoPlay = false
-  }
-
-  // Fires on EVERY foreground activation of éist on the car screen — cold start,
-  // warm start, and returning after another audio app was used. didConnect only
-  // fires once per scene connection, so triggering playback there left the app
-  // dead on re-entry (list showing, disabled play button): the other app owned
-  // the now-playing role and no play request ever reached JS. Auto-playing here
-  // reclaims the session every time the user opens éist. The JS side skips the
-  // request when the stream is already playing, so glancing at Maps and back
-  // does not restart a healthy stream.
-  func sceneDidBecomeActive(_ scene: UIScene) {
-    if rootTemplateSet {
-      startPlaybackAndShowNowPlaying(animated: false)
-    } else {
-      pendingAutoPlay = true
-    }
   }
 
   private func makeRootTemplate() -> CPListTemplate {
     let item = CPListItem(text: "éist", detailText: "live")
     item.handler = { [weak self] _, completion in
-      // Fallback path: the list is normally skipped (see didConnect), but if the
-      // user backs out to it, tapping the item still starts playback + Now Playing.
-      self?.startPlaybackAndShowNowPlaying(animated: true)
+      self?.interfaceController?.pushTemplate(CPNowPlayingTemplate.shared, animated: true, completion: nil)
       completion()
     }
-    let section = CPListSection(items: [item])
-    return CPListTemplate(title: "éist", sections: [section])
-  }
-
-  // Post the play request to JS (react-native-track-player, via EistCarPlayBridge)
-  // then push Now Playing. Kept together because Now Playing's transport controls
-  // only go live once éist is the active now-playing app, which only happens after
-  // JS actually starts the stream.
-  private func startPlaybackAndShowNowPlaying(animated: Bool) {
-    // Set the buffer flag FIRST, then post. If the JS runtime isn't ready yet
-    // (cold CarPlay launch), the post is dropped but EistCarPlayBridge replays this
-    // flag as soon as JS subscribes — so the play request is never lost.
-    EistCarPlayBridge.pendingPlay = true
-    NotificationCenter.default.post(name: EistCarPlayBridge.playRequested, object: nil)
-    showNowPlaying(animated: animated)
-  }
-
-  // Push (never root) the system Now Playing screen. Its play/stop button drives
-  // MPRemoteCommandCenter, which react-native-track-player handles in
-  // trackPlayerService.js — so tapping play here starts the live stream.
-  private func showNowPlaying(animated: Bool) {
-    let nowPlaying = CPNowPlayingTemplate.shared
-    nowPlaying.isUpNextButtonEnabled = false
-    nowPlaying.isAlbumArtistButtonEnabled = false
-    if interfaceController?.topTemplate !== nowPlaying {
-      interfaceController?.pushTemplate(nowPlaying, animated: animated, completion: nil)
-    }
+    return CPListTemplate(title: "éist", sections: [CPListSection(items: [item])])
   }
 }
 `;
 
-// Hosts the normal phone UI. Because CarPlay puts the app on the scene
-// lifecycle, the phone window must be created here (from its UIWindowScene)
-// rather than in the AppDelegate. It reuses the React Native root view the
-// AppDelegate built at launch (AppDelegate.reactRootView).
+// Hosts the normal phone UI. CarPlay forces the scene lifecycle, so the phone
+// window must be created here (from its UIWindowScene) rather than in the
+// AppDelegate. Reuses the RN root view the AppDelegate built at launch.
 const PHONE_SCENE_DELEGATE_SWIFT = `import UIKit
 
 @objc(PhoneSceneDelegate)
@@ -179,17 +88,13 @@ class PhoneSceneDelegate: UIResponder, UIWindowSceneDelegate {
     guard let windowScene = scene as? UIWindowScene else { return }
 
     let window = UIWindow(windowScene: windowScene)
-    // Brand purple (#4733FF) so any moment the RN view isn't mounted reads as
-    // the éist background, not a bare black screen — and makes a genuine
-    // wiring failure diagnosable rather than silent.
+    // Brand purple so a moment without the RN view mounted reads as the éist
+    // background, not a bare black screen.
     window.backgroundColor = UIColor(red: 71.0 / 255.0, green: 51.0 / 255.0, blue: 255.0 / 255.0, alpha: 1.0)
 
     let rootViewController = UIViewController()
     rootViewController.view.backgroundColor = window.backgroundColor
 
-    // Reuse the root view the AppDelegate built at launch. Fall back to building
-    // it here (and cache it back) if it's missing — e.g. odd launch ordering or
-    // a scene reconnect — so the phone UI never comes up empty.
     if let appDelegate = UIApplication.shared.delegate as? AppDelegate {
       var rootView = appDelegate.reactRootView
       if rootView == nil {
@@ -212,78 +117,6 @@ class PhoneSceneDelegate: UIResponder, UIWindowSceneDelegate {
 }
 `;
 
-// Tiny native → JS bridge so the CarPlay list-item tap can start playback.
-// CarPlay's Now Playing template cannot cold-start audio (it only controls the
-// already-active now-playing app), and playback lives in react-native-track-
-// player on the JS side. This RCTEventEmitter forwards a NotificationCenter post
-// (from CarPlaySceneDelegate) to JS, where TrackPlayerContext calls play().
-// newArch is off in this app, so a classic RCTEventEmitter + RCT_EXTERN_MODULE
-// registration is the right shape. The module only exists in CarPlay builds; JS
-// guards on NativeModules.EistCarPlayBridge being present.
-const EIST_CARPLAY_BRIDGE_SWIFT = `import Foundation
-import React
-
-@objc(EistCarPlayBridge)
-class EistCarPlayBridge: RCTEventEmitter {
-  // Posted by CarPlaySceneDelegate when the éist list item is tapped.
-  static let playRequested = Notification.Name("EistCarPlayPlayRequested")
-  // Emitted to JS (listened for in TrackPlayerContext).
-  static let playEvent = "EistCarPlayPlay"
-
-  // ── Cold-start race buffer ────────────────────────────────────────────────
-  // The CarPlay list/Now Playing UI is drawn NATIVELY by CarPlaySceneDelegate, so
-  // it appears and accepts a tap before React Native has finished starting and this
-  // module has registered its notification observer. A tap in that window would
-  // post into the void and be lost — the exact "dead play button on first open"
-  // symptom. So CarPlaySceneDelegate ALSO sets this static flag on tap, and we
-  // replay it the moment JS attaches its listener (startObserving). Static because
-  // the flag must survive from "scene tapped" until "module instantiated + JS
-  // subscribed", which may span the whole RN cold-launch.
-  static var pendingPlay = false
-
-  private var hasListeners = false
-
-  override static func requiresMainQueueSetup() -> Bool { false }
-
-  override func supportedEvents() -> [String]! { [EistCarPlayBridge.playEvent] }
-
-  // RCTEventEmitter calls these when JS adds/removes its first/last listener.
-  override func startObserving() {
-    hasListeners = true
-    NotificationCenter.default.addObserver(
-      self,
-      selector: #selector(handlePlayRequested),
-      name: EistCarPlayBridge.playRequested,
-      object: nil)
-    // Deliver a tap that landed before JS was ready to hear it.
-    if EistCarPlayBridge.pendingPlay {
-      EistCarPlayBridge.pendingPlay = false
-      sendEvent(withName: EistCarPlayBridge.playEvent, body: nil)
-    }
-  }
-
-  override func stopObserving() {
-    hasListeners = false
-    NotificationCenter.default.removeObserver(self)
-  }
-
-  @objc private func handlePlayRequested() {
-    // JS is subscribed, so consume the buffered intent and forward immediately.
-    EistCarPlayBridge.pendingPlay = false
-    sendEvent(withName: EistCarPlayBridge.playEvent, body: nil)
-  }
-}
-`;
-
-// ObjC registration is required for a Swift RCTEventEmitter to be exported to the
-// JS module registry under the old architecture.
-const EIST_CARPLAY_BRIDGE_OBJC = `#import <React/RCTBridgeModule.h>
-#import <React/RCTEventEmitter.h>
-
-@interface RCT_EXTERN_MODULE(EistCarPlayBridge, RCTEventEmitter)
-@end
-`;
-
 function withCarPlayEntitlement(config) {
   return withEntitlementsPlist(config, (config) => {
     config.modResults[CARPLAY_AUDIO_ENTITLEMENT] = true;
@@ -296,10 +129,9 @@ function withCarPlaySceneManifest(config) {
     const infoPlist = config.modResults;
     const existing = infoPlist.UIApplicationSceneManifest || {};
 
-    // Declare BOTH scene roles. The phone window role is what keeps the normal
-    // app UI alive once multiple scenes are enabled; the CarPlay role adds the
-    // car Now Playing screen. $(PRODUCT_MODULE_NAME) is expanded by Xcode at
-    // build time, e.g. "eist.PhoneSceneDelegate".
+    // Declare both scene roles: the phone window role keeps the normal app UI
+    // alive once multiple scenes are enabled, and the CarPlay role adds the
+    // car screen. $(PRODUCT_MODULE_NAME) is expanded by Xcode at build time.
     infoPlist.UIApplicationSceneManifest = {
       ...existing,
       UIApplicationSupportsMultipleScenes: true,
@@ -329,9 +161,7 @@ function withCarPlaySceneManifest(config) {
 /**
  * Patch the (generated) AppDelegate so it no longer creates its own UIWindow
  * and instead exposes the RN root view for PhoneSceneDelegate to display.
- *
- * Fails loudly if the expected code shape isn't found — better a clear build
- * error than silently shipping the old black-screen behaviour.
+ * Fails loudly if the expected code shape isn't found.
  */
 function withCarPlayAppDelegate(config) {
   return withAppDelegate(config, (config) => {
@@ -344,12 +174,11 @@ function withCarPlayAppDelegate(config) {
 
     let contents = config.modResults.contents;
 
-    // Idempotency: skip if we've already patched.
+    // Idempotency: skip if already patched.
     if (contents.includes('var reactRootView: UIView?')) {
       return config;
     }
 
-    // 1. Expose the RN root view so PhoneSceneDelegate can host it.
     if (!/var window: UIWindow\?/.test(contents)) {
       throw new Error(
         "[withCarPlay] Could not find `var window: UIWindow?` in AppDelegate — " +
@@ -361,8 +190,6 @@ function withCarPlayAppDelegate(config) {
       'var window: UIWindow?\n  // Built in didFinishLaunching; attached to the phone window by\n  // PhoneSceneDelegate (CarPlay forces the scene lifecycle). See withCarPlay.js.\n  var reactRootView: UIView?'
     );
 
-    // 2. Replace the AppDelegate's window creation + startReactNative(in:) with
-    //    root-view creation only. The scene owns the window now.
     const windowBootRegex =
       /window = UIWindow\(frame: UIScreen\.main\.bounds\)\s*\n\s*factory\.startReactNative\(\s*withModuleName:\s*"main",\s*in:\s*window,\s*launchOptions:\s*launchOptions\)/;
 
@@ -393,11 +220,8 @@ function withCarPlaySceneDelegateFiles(config) {
   const files = [
     { name: 'CarPlaySceneDelegate.swift', source: CARPLAY_SCENE_DELEGATE_SWIFT },
     { name: 'PhoneSceneDelegate.swift', source: PHONE_SCENE_DELEGATE_SWIFT },
-    { name: 'EistCarPlayBridge.swift', source: EIST_CARPLAY_BRIDGE_SWIFT },
-    { name: 'EistCarPlayBridge.m', source: EIST_CARPLAY_BRIDGE_OBJC },
   ];
 
-  // Write the Swift sources into ios/<project>/.
   config = withDangerousMod(config, [
     'ios',
     (config) => {
@@ -416,7 +240,6 @@ function withCarPlaySceneDelegateFiles(config) {
     },
   ]);
 
-  // Register each Swift file with the Xcode target so it compiles.
   config = withXcodeProject(config, (config) => {
     const projectName = config.modRequest.projectName;
     for (const file of files) {

--- a/utils/playbackUiState.ts
+++ b/utils/playbackUiState.ts
@@ -14,7 +14,12 @@
 
 // The transient states RNTP passes through while (re)starting a live stream.
 // State.Connecting is an alias of State.Loading, so it's covered by 'loading'.
-const TRANSIENT_STARTUP_STATES = new Set(['loading', 'buffering', 'ready']);
+// 'stopped' and 'none' are included because play() calls cleanResetPlayer()
+// which fires stop()/reset() before TrackPlayer.play() — those events arrive
+// asynchronously and would flicker the button if not held steady.  This is safe:
+// user-initiated stop() clears userPlay BEFORE calling TrackPlayer.stop(), so
+// genuine stops still resolve to false.
+const TRANSIENT_STARTUP_STATES = new Set(['loading', 'buffering', 'ready', 'stopped', 'none']);
 
 /**
  * @param state         the raw PlaybackState string from RNTP (State enum value)
@@ -26,6 +31,6 @@ export function resolveIsPlaying(state: string, userWantsPlay: boolean): boolean
   if (state === 'playing') return true;
   // Hold steady through startup/rebuffer churn while the user wants playback.
   if (userWantsPlay && TRANSIENT_STARTUP_STATES.has(state)) return true;
-  // Stopped / paused / none / ended / error → genuinely not playing.
+  // Paused / ended / error (or stopped/none with userPlay false) → not playing.
   return false;
 }


### PR DESCRIPTION
## What this brings to `main`

This PR carries **fixcar's 3 unmerged commits** (Aidan Reilly's CarPlay / play-button / metadata work) **plus one correctness fix** surfaced in review:

- `aca7510` — CarPlay play button and metadata dedup, fix SpinningLogo hooks order
- `19ebe1e` — suppress play button flicker from cleanResetPlayer state events
- `231cb1b` — smooth play button and background artwork through recovery churn
- **`177de4d` — fix: metadata dedup permanently suppressing failed updates** (new, review finding 2)

It is file-disjoint from the `expo54-api36-upgrade` PR, so the two can merge into `main` in **any order** without conflicts.

## Finding 2 fix (`177de4d`)

`updateMetadata` recorded the dedup key **before** the readiness / queue / bounds checks and the actual `updateMetadataForTrack` call. So any early return (e.g. cold-start with the player not yet ready) or throw **permanently suppressed every later metadata update for that show**, leaving stale lock-screen / Android Auto / CarPlay metadata. Fix:

- record the local dedup key **only after** a successful `updateMetadataForTrack`;
- read the live `isPlayerReadyRef` instead of the render-captured `isPlayerReady` state (cold-start stale-closure);
- give cast its **own** success key (`lastCastMetadataRef`) so a deferred local update and a cast update can't mask each other.

## Notes / review flags

- A third review finding — the now-dead `NativeModules.EistCarPlayBridge` `useEffect` — was **left as-is**: `aca7510` intentionally removed the bridge generation in favour of driving `MPRemoteCommandCenter` directly. However, `main` previously *did* wire that bridge, so **CarPlay cold-start-from-car changed approach here** — worth an iOS CarPlay smoke test to confirm tapping éist in the car still starts audio.
- **iOS is not binary-validated** in this branch (no Mac / EAS iOS build available here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
